### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,4 +1,4 @@
 DigisparkTech22Begin	KEYWORD2
 DigisparkTech22	KEYWORD2
-DigisparkTech22Read KEYWORD2
+DigisparkTech22Read	KEYWORD2
 DigisparkTech22Delay	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords